### PR TITLE
Fix README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ lunapipe --prompts my_prompt_templates -t test -p testparam="Hello, world!" "Is 
 ```
 
 #### Models
-You can use different models to generate your code. For example, if you want to generate a go function that prints "Hello World", you can use the following model:
+You can use different models to generate your code. For example, if you want to generate a completion using `gpt-4`, you can use the `-m` flag:
 ```bash
-lunapipe -m gpt-4 "Read values from a map"
+lunapipe -m gpt-4 "What are the improvements in GPT-4 compared to previous GPT models?"
 ```
 
 The default model is `gpt-3.5-turbo`, but you can use any of the following models:

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ This repo is written in Go (also known as Golang).
 #### Templates
 You can use templates to generate code. For example, if you want to generate a go function that prints "Hello World", you can use the following template:
 ```bash
-lunapipe -t function -p language=go "Read values from a map"
+lunapipe -t function -p language=go "Print 'Hello World'"
 
 # create an alias to code even faster
 alias aigo="lunapipe -t function -p language=go"


### PR DESCRIPTION
There's a couple of typos / inconsistency in the README where the descriptions of example usage don't quite match the snippets - I've fixed these here!

I've made them separate commits, but obviously I'm happy to squash them (or make any other desired changes for that matter)!